### PR TITLE
Changed the CRA prefix to VITE since the react app is from vite not cra

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,6 @@ function App() {
 
   useEffect(() => {
     fetchData();
-    console.log(apiKey, 'api keeeeeeeeeeeeeeeey');
   }, []);
 
   const fetchData = () => { 


### PR DESCRIPTION
Changed the CRA prefix to VITE since the react app is from vite not cra